### PR TITLE
Fix for bug where onSuccess does not always respect the specified queue.

### DIFF
--- a/Sources/Propagate/PromiseAndFuture/Future.swift
+++ b/Sources/Propagate/PromiseAndFuture/Future.swift
@@ -89,7 +89,7 @@ public class Future<T, E: Error> {
             child.onSuccess(onQueue: overrideQueue, callback)
         }
         else {
-            self.appendChild().onSuccess(callback)
+            self.appendChild().onSuccess(onQueue: overrideQueue, callback)
         }
         return self
     }

--- a/Tests/PropagateTests/SubscriberCombineTests.swift
+++ b/Tests/PropagateTests/SubscriberCombineTests.swift
@@ -19,21 +19,6 @@ class SubscriberCombineTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }
 
 private enum TestError: Error {


### PR DESCRIPTION
Fixed bug where child futures were not receiving the overridden dispatch queue passed into onSuccess(onQueue:_:)