### PR TITLE
Simplified internal logging methods

### DIFF
--- a/Sources/Propagate/PublisherAndSubscriber/PropagateDebug.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/PropagateDebug.swift
@@ -103,19 +103,19 @@ extension Subscriber: CustomStringConvertible {
 }
 
 internal extension Publisher {
-    func safePrint(_ message: String, logType: LogType) {
+    func log(_ message: String, logType: LogType) {
         Propagate.safePrint(message, logType: logType, loggingCombo: loggingCombo)
     }
 }
 
 internal extension Subscriber {
-    func safePrint(_ message: String, logType: LogType) {
+    func log(_ message: String, logType: LogType) {
         Propagate.safePrint(message, logType: logType, loggingCombo: loggingCombo)
     }
 }
 
 internal extension ValueOnlySubscriber {
-    func safePrint(_ message: String, logType: LogType) {
+    func log(_ message: String, logType: LogType) {
         Propagate.safePrint(message, logType: logType, loggingCombo: loggingCombo)
     }
 }

--- a/Sources/Propagate/PublisherAndSubscriber/PropagateDebug.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/PropagateDebug.swift
@@ -30,7 +30,7 @@ public enum LoggingMethod {
     case debugPrint
 }
 
-internal func safePrint(_ message: String, logType: LogType, loggingCombo: LoggingCombo?) {
+private func safePrint(_ message: String, logType: LogType, loggingCombo: LoggingCombo?) {
     guard let combo = loggingCombo else {
         return
     }
@@ -47,7 +47,9 @@ internal func safePrint(_ message: String, logType: LogType, loggingCombo: Loggi
     
     switch loggingCombo?.loggingMethod {
     case .debugPrint, nil:
+#if DEBUG
         print(output)
+#endif
     case .external(let hook):
         hook(output)
     }
@@ -98,6 +100,24 @@ extension Subscriber: CustomStringConvertible {
         return "Subscriber<\(T.self),\(E.self)>(\(memoryAddressStringFor(self)))"
     }
     
+}
+
+internal extension Publisher {
+    func safePrint(_ message: String, logType: LogType) {
+        Propagate.safePrint(message, logType: logType, loggingCombo: loggingCombo)
+    }
+}
+
+internal extension Subscriber {
+    func safePrint(_ message: String, logType: LogType) {
+        Propagate.safePrint(message, logType: logType, loggingCombo: loggingCombo)
+    }
+}
+
+internal extension ValueOnlySubscriber {
+    func safePrint(_ message: String, logType: LogType) {
+        Propagate.safePrint(message, logType: logType, loggingCombo: loggingCombo)
+    }
 }
 
 // MARK: - interface

--- a/Sources/Propagate/PublisherAndSubscriber/Publisher.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Publisher.swift
@@ -25,7 +25,7 @@ public class Publisher<T, E: Error> {
     /// Emits a new `StreamState`. If this publisher has previously been
     /// cancelled, this method will be a no-op.
     internal func publishNewState(_ state: State) {
-        safePrint("Publishing state \(state). -- \(self)", logType: .pubSub)
+        log("Publishing state \(state). -- \(self)", logType: .pubSub)
         lockQueue.async {
             if self.isCancelled {
                 return
@@ -35,7 +35,7 @@ public class Publisher<T, E: Error> {
     }
     
     deinit {
-        safePrint("Releasing \(self) from memory.", logType: .lifeCycle)
+        log("Releasing \(self) from memory.", logType: .lifeCycle)
         // The asynchronous cancelAll() can't be called from deinit
         // because it results in a bad access crash.
         handleCancellation()
@@ -60,7 +60,7 @@ public class Publisher<T, E: Error> {
         lockQueue.async { [weak self] in
             self?.subscribers.insert(newSub)
         }
-        safePrint(
+        log(
             "Instance \(memoryAddressStringFor(self)) generating new subscriber --> \(newSub)",
             logType: .lifeCycle
         )
@@ -140,7 +140,7 @@ extension Publisher: PropagateDebuggable {
 private extension Publisher {
     
     func removeSubscriber(_ subscriber: Subscriber<T,E>) {
-        safePrint("Removing \(subscriber) from \(self)", logType: .pubSub)
+        log("Removing \(subscriber) from \(self)", logType: .pubSub)
         self.subscribers.pruneIf { $0 === subscriber }
         subscriber.receive(.cancelled)
     }
@@ -151,9 +151,9 @@ private extension Publisher {
         }
         isCancelled = true
         let removedSubscribers = subscribers.removeAll()
-        safePrint("Removing subscribers: \(removedSubscribers)", logType: .pubSub)
+        log("Removing subscribers: \(removedSubscribers)", logType: .pubSub)
         removedSubscribers.forEach {
-            safePrint("Sending cancellation signal to \($0)", logType: .pubSub)
+            log("Sending cancellation signal to \($0)", logType: .pubSub)
             $0.receive(.cancelled)
         }
     }

--- a/Sources/Propagate/PublisherAndSubscriber/Publisher.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Publisher.swift
@@ -25,7 +25,7 @@ public class Publisher<T, E: Error> {
     /// Emits a new `StreamState`. If this publisher has previously been
     /// cancelled, this method will be a no-op.
     internal func publishNewState(_ state: State) {
-        safePrint("Publishing state \(state). -- \(self)", logType: .pubSub, loggingCombo: loggingCombo)
+        safePrint("Publishing state \(state). -- \(self)", logType: .pubSub)
         lockQueue.async {
             if self.isCancelled {
                 return
@@ -35,11 +35,7 @@ public class Publisher<T, E: Error> {
     }
     
     deinit {
-        safePrint(
-            "Releasing \(self) from memory.",
-            logType: .lifeCycle,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Releasing \(self) from memory.", logType: .lifeCycle)
         // The asynchronous cancelAll() can't be called from deinit
         // because it results in a bad access crash.
         handleCancellation()
@@ -64,7 +60,10 @@ public class Publisher<T, E: Error> {
         lockQueue.async { [weak self] in
             self?.subscribers.insert(newSub)
         }
-        logPublisher(self, generatingNewSubscriber: newSub, loggingCombo: loggingCombo)
+        safePrint(
+            "Instance \(memoryAddressStringFor(self)) generating new subscriber --> \(newSub)",
+            logType: .lifeCycle
+        )
         return newSub
     }
     
@@ -141,7 +140,7 @@ extension Publisher: PropagateDebuggable {
 private extension Publisher {
     
     func removeSubscriber(_ subscriber: Subscriber<T,E>) {
-        safePrint("Removing \(subscriber) from \(self)", logType: .pubSub, loggingCombo: loggingCombo)
+        safePrint("Removing \(subscriber) from \(self)", logType: .pubSub)
         self.subscribers.pruneIf { $0 === subscriber }
         subscriber.receive(.cancelled)
     }
@@ -152,9 +151,9 @@ private extension Publisher {
         }
         isCancelled = true
         let removedSubscribers = subscribers.removeAll()
-        safePrint("Removing subscribers: \(removedSubscribers)", logType: .pubSub, loggingCombo: loggingCombo)
+        safePrint("Removing subscribers: \(removedSubscribers)", logType: .pubSub)
         removedSubscribers.forEach {
-            safePrint("Sending cancellation signal to \($0)", logType: .pubSub, loggingCombo: loggingCombo)
+            safePrint("Sending cancellation signal to \($0)", logType: .pubSub)
             $0.receive(.cancelled)
         }
     }
@@ -243,16 +242,4 @@ public extension Publisher where T == Void {
         publish(())
     }
     
-}
-
-private func logPublisher<T,E:Error>(
-    _ pub: Publisher<T,E>,
-    generatingNewSubscriber sub: Subscriber<T,E>,
-    loggingCombo: LoggingCombo?
-) {
-    safePrint(
-        "Instance \(memoryAddressStringFor(pub)) generating new subscriber --> \(sub)",
-        logType: .lifeCycle,
-        loggingCombo: loggingCombo
-    )
 }

--- a/Sources/Propagate/PublisherAndSubscriber/Subscriber+Filter.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Subscriber+Filter.swift
@@ -19,7 +19,7 @@ public extension Subscriber {
             publisher.publishNewState(state)
         }
         
-        safePrint("Filtering \(self)", logType: .operators)
+        log("Filtering \(self)", logType: .operators)
         
         return publisher.subscriber()
             .onCancelled {
@@ -90,7 +90,7 @@ public extension Subscriber where T: Equatable {
             }
         }
         
-        safePrint("Removing contiguous duplicates values from \(self).", logType: .operators)
+        log("Removing contiguous duplicates values from \(self).", logType: .operators)
         return publisher.subscriber()
             .onCancelled {
                 _ = self // Capturing self to keep subscriber alive for easier chaining.
@@ -126,7 +126,7 @@ public extension Subscriber where T: Equatable, E: Equatable {
             }
         }
         
-        safePrint("Removing contiguous duplicate values from \(self).", logType: .operators)
+        log("Removing contiguous duplicate values from \(self).", logType: .operators)
         
         return publisher.subscriber()
             .onCancelled {

--- a/Sources/Propagate/PublisherAndSubscriber/Subscriber+Filter.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Subscriber+Filter.swift
@@ -19,11 +19,7 @@ public extension Subscriber {
             publisher.publishNewState(state)
         }
         
-        safePrint(
-            "Filtering \(self)",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Filtering \(self)", logType: .operators)
         
         return publisher.subscriber()
             .onCancelled {
@@ -94,11 +90,7 @@ public extension Subscriber where T: Equatable {
             }
         }
         
-        safePrint(
-            "Removing contiguous duplicates values from \(self).",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Removing contiguous duplicates values from \(self).", logType: .operators)
         return publisher.subscriber()
             .onCancelled {
                 _ = self // Capturing self to keep subscriber alive for easier chaining.
@@ -134,11 +126,7 @@ public extension Subscriber where T: Equatable, E: Equatable {
             }
         }
         
-        safePrint(
-            "Removing contiguous duplicates values from \(self).",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Removing contiguous duplicate values from \(self).", logType: .operators)
         
         return publisher.subscriber()
             .onCancelled {

--- a/Sources/Propagate/PublisherAndSubscriber/Subscriber+Map.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Subscriber+Map.swift
@@ -23,7 +23,7 @@ public extension Subscriber {
         
         let newSubscriber = newPublisher.subscriber()
         
-        safePrint(
+        log(
             "Mapping states from StreamState<\(T.self),\(E.self)> to StreamState<\(NewT.self),\(NewE.self)>",
             logType: .operators
         )
@@ -37,7 +37,7 @@ public extension Subscriber {
     /// this subscriber to `.data` values of a different type on a new subscriber.
     /// Other states (`.error` and `.cancelled`) pass through like normal.
     func mapValues<NewT>(_ transform: @escaping (T) -> NewT) -> Subscriber<NewT, E> {
-        safePrint("Mapping values from \(T.self) to \(NewT.self)", logType: .operators)
+        log("Mapping values from \(T.self) to \(NewT.self)", logType: .operators)
         return mapStates { oldState in
             switch oldState {
             case .data(let data):
@@ -69,7 +69,7 @@ public extension Subscriber {
     /// this subscriber to `.error` errors of a different type on a new subscriber.
     /// Other states (`.data` and `.cancelled`) pass through like normal.
     func mapErrors<NewE: Error>(_ transform: @escaping (E) -> NewE) -> Subscriber<T, NewE> {
-        safePrint("Mapping errors from \(E.self) to \(NewE.self).", logType: .operators)
+        log("Mapping errors from \(E.self) to \(NewE.self).", logType: .operators)
         return mapStates { oldState in
             switch oldState {
             case .data(let data):

--- a/Sources/Propagate/PublisherAndSubscriber/Subscriber+Map.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Subscriber+Map.swift
@@ -25,8 +25,7 @@ public extension Subscriber {
         
         safePrint(
             "Mapping states from StreamState<\(T.self),\(E.self)> to StreamState<\(NewT.self),\(NewE.self)>",
-            logType: .operators,
-            loggingCombo: loggingCombo
+            logType: .operators
         )
         return newSubscriber
             .onCancelled {
@@ -38,11 +37,7 @@ public extension Subscriber {
     /// this subscriber to `.data` values of a different type on a new subscriber.
     /// Other states (`.error` and `.cancelled`) pass through like normal.
     func mapValues<NewT>(_ transform: @escaping (T) -> NewT) -> Subscriber<NewT, E> {
-        safePrint(
-            "Mapping values from \(T.self) to \(NewT.self)",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Mapping values from \(T.self) to \(NewT.self)", logType: .operators)
         return mapStates { oldState in
             switch oldState {
             case .data(let data):
@@ -74,11 +69,7 @@ public extension Subscriber {
     /// this subscriber to `.error` errors of a different type on a new subscriber.
     /// Other states (`.data` and `.cancelled`) pass through like normal.
     func mapErrors<NewE: Error>(_ transform: @escaping (E) -> NewE) -> Subscriber<T, NewE> {
-        safePrint(
-            "Mapping errors from \(E.self) to \(NewE.self).",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Mapping errors from \(E.self) to \(NewE.self).", logType: .operators)
         return mapStates { oldState in
             switch oldState {
             case .data(let data):

--- a/Sources/Propagate/PublisherAndSubscriber/Subscriber.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Subscriber.swift
@@ -27,7 +27,7 @@ public class Subscriber<T, E: Error> {
     }
     
     deinit {
-        safePrint("Releasing \(self) from memory.", logType: .lifeCycle)
+        log("Releasing \(self) from memory.", logType: .lifeCycle)
         cancel()
     }
     
@@ -85,7 +85,7 @@ internal extension Subscriber {
     /// its publisher. This will result in this subscriber
     /// immediately receiving a `.cancelled` signal.
     func cancel() {
-        safePrint("Cancelling \(self)...", logType: .lifeCycle)
+        log("Cancelling \(self)...", logType: .lifeCycle)
         canceller.cancel(for: self)
         receive(.cancelled)
     }
@@ -100,7 +100,7 @@ private extension Subscriber {
         guard !isCancelled else {
             return
         }
-        safePrint("Received \(state). -- \(self)", logType: .pubSub)
+        log("Received \(state). -- \(self)", logType: .pubSub)
         callbacks.forEach { (queue, action) in
             queue.async { action(state) }
         }

--- a/Sources/Propagate/PublisherAndSubscriber/Subscriber.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/Subscriber.swift
@@ -27,11 +27,7 @@ public class Subscriber<T, E: Error> {
     }
     
     deinit {
-        safePrint(
-            "Releasing \(self) from memory.",
-            logType: .lifeCycle,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Releasing \(self) from memory.", logType: .lifeCycle)
         cancel()
     }
     
@@ -89,11 +85,7 @@ internal extension Subscriber {
     /// its publisher. This will result in this subscriber
     /// immediately receiving a `.cancelled` signal.
     func cancel() {
-        safePrint(
-            "Cancelling \(self)...",
-            logType: .lifeCycle,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Cancelling \(self)...", logType: .lifeCycle)
         canceller.cancel(for: self)
         receive(.cancelled)
     }
@@ -108,11 +100,7 @@ private extension Subscriber {
         guard !isCancelled else {
             return
         }
-        safePrint(
-            "Received \(state). -- \(self)",
-            logType: .pubSub,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Received \(state). -- \(self)", logType: .pubSub)
         callbacks.forEach { (queue, action) in
             queue.async { action(state) }
         }

--- a/Sources/Propagate/PublisherAndSubscriber/ValueOnlySubscriber.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/ValueOnlySubscriber.swift
@@ -37,7 +37,7 @@ public class ValueOnlySubscriber<T> {
     private var valueCallbacks = [ValueExecutionPair]()
     private var cancelCallbacks = [CancelExecutionPair]()
     private(set) public var isCancelled = false
-    private var loggingCombo: LoggingCombo?
+    internal var loggingCombo: LoggingCombo?
     
     fileprivate init() {}
     
@@ -73,8 +73,7 @@ public class ValueOnlySubscriber<T> {
         
         safePrint(
             "Inflating ValueOnlySubscriber<T\(T.self)> to \(Subscriber<T,E>.self)",
-            logType: .operators,
-            loggingCombo: loggingCombo
+            logType: .operators
         )
         return publisher.subscriber().onCancelled {
             _ = self // Capturing self to keep subscriber alive for easier chaining.
@@ -82,20 +81,12 @@ public class ValueOnlySubscriber<T> {
     }
     
     deinit {
-        safePrint(
-            "Releasing \(self) from memory.",
-            logType: .lifeCycle,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Releasing \(self) from memory.", logType: .lifeCycle)
         cancel()
     }
     
     private func executeValueCallbacks(with value: T) {
-        safePrint(
-            "Received \(value). -- \(self)",
-            logType: .lifeCycle,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Received \(value). -- \(self)", logType: .lifeCycle)
         valueCallbacks.forEach { (queue, action) in
             queue.async { action(value) }
         }
@@ -108,11 +99,7 @@ public class ValueOnlySubscriber<T> {
     }
     
     private func cancel() {
-        safePrint(
-            "Cancelling \(self)...",
-            logType: .lifeCycle,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Cancelling \(self)...", logType: .lifeCycle)
         lockQueue.async { [weak self] in
             self?.isCancelled = true
             self?.valueCallbacks.removeAll()
@@ -194,22 +181,14 @@ public extension ValueOnlySubscriber {
     /// closure for mapping from one type to the other.
     @discardableResult func map<NewT>(mapping: @escaping (T) -> NewT) -> ValueOnlySubscriber<NewT> {
         let newSub = ValueOnlySubscriber<NewT>(other: self, mapBlock: mapping)
-        safePrint(
-            "Mapping from \(T.self) to \(NewT.self). -- \(self)",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Mapping from \(T.self) to \(NewT.self). -- \(self)", logType: .operators)
         return newSub
     }
     
     /// Generates a new ValueOnlySubscriber of a different type, based on the supplied
     /// closure for mapping from one type to the other.
     @discardableResult func compactMap<NewT>(mapping: @escaping (T) -> NewT?) -> ValueOnlySubscriber<NewT> {
-        safePrint(
-            "Compact mapping from \(T.self) to \(NewT.self). -- \(self)",
-            logType: .operators,
-            loggingCombo: loggingCombo
-        )
+        safePrint("Compact mapping from \(T.self) to \(NewT.self). -- \(self)", logType: .operators)
         
         let newSub = ValueOnlySubscriber<NewT>()
         onNext { value in
@@ -263,8 +242,7 @@ public extension ValueOnlySubscriber where T: Equatable {
         
         safePrint(
             "Removing contiguous duplicates from \(self)",
-            logType: .operators,
-            loggingCombo: loggingCombo
+            logType: .operators
         )
         return new.onCancelled {
             _ = self
@@ -296,11 +274,7 @@ public extension ValueOnlySubscriber {
             }
         }
         
-        safePrint(
-            "Combining ValueOnlySubscribers <\(T.self)> and <\(T2.self)>: -- \(memoryAddressStringFor(sub1)) & \(memoryAddressStringFor(sub2))",
-            logType: .operators,
-            loggingCombo: sub1.loggingCombo ?? sub2.loggingCombo // This will probably be a problem at some point.
-        )
+        logForCombiningIfPossible(sub1, sub2)
         
         return new.onCancelled {
             _ = sub1
@@ -437,4 +411,26 @@ public extension ValueOnlySubscriber {
         return ValueOnlySubscriber.combine(self, sub2, sub3, sub4, sub5, sub6)
     }
     
+}
+
+// MARK: - Private / Helpers
+
+private func logMessageForCombining<T1, T2>(_ sub1: ValueOnlySubscriber<T1>, and sub2: ValueOnlySubscriber<T2>) -> String {
+    "Combining ValueOnlySubscribers <\(T1.self)> and <\(T2.self)>: -- \(memoryAddressStringFor(sub1)) & \(memoryAddressStringFor(sub2))"
+}
+
+private func logForCombiningIfPossible<T1,T2>(_ sub1: ValueOnlySubscriber<T1>, _ sub2: ValueOnlySubscriber<T2>) {
+    // This logging logic will probably become a problem at some point.
+    if sub1.loggingCombo != nil {
+        sub1.safePrint(
+            logMessageForCombining(sub1, and: sub2),
+            logType: .operators
+        )
+    }
+    else if sub2.loggingCombo != nil {
+        sub2.safePrint(
+            logMessageForCombining(sub1, and: sub2),
+            logType: .operators
+        )
+    }
 }

--- a/Sources/Propagate/PublisherAndSubscriber/ValueOnlySubscriber.swift
+++ b/Sources/Propagate/PublisherAndSubscriber/ValueOnlySubscriber.swift
@@ -71,7 +71,7 @@ public class ValueOnlySubscriber<T> {
         
         onNext { publisher.publish($0) }
         
-        safePrint(
+        log(
             "Inflating ValueOnlySubscriber<T\(T.self)> to \(Subscriber<T,E>.self)",
             logType: .operators
         )
@@ -81,12 +81,12 @@ public class ValueOnlySubscriber<T> {
     }
     
     deinit {
-        safePrint("Releasing \(self) from memory.", logType: .lifeCycle)
+        log("Releasing \(self) from memory.", logType: .lifeCycle)
         cancel()
     }
     
     private func executeValueCallbacks(with value: T) {
-        safePrint("Received \(value). -- \(self)", logType: .lifeCycle)
+        log("Received \(value). -- \(self)", logType: .lifeCycle)
         valueCallbacks.forEach { (queue, action) in
             queue.async { action(value) }
         }
@@ -99,7 +99,7 @@ public class ValueOnlySubscriber<T> {
     }
     
     private func cancel() {
-        safePrint("Cancelling \(self)...", logType: .lifeCycle)
+        log("Cancelling \(self)...", logType: .lifeCycle)
         lockQueue.async { [weak self] in
             self?.isCancelled = true
             self?.valueCallbacks.removeAll()
@@ -181,14 +181,14 @@ public extension ValueOnlySubscriber {
     /// closure for mapping from one type to the other.
     @discardableResult func map<NewT>(mapping: @escaping (T) -> NewT) -> ValueOnlySubscriber<NewT> {
         let newSub = ValueOnlySubscriber<NewT>(other: self, mapBlock: mapping)
-        safePrint("Mapping from \(T.self) to \(NewT.self). -- \(self)", logType: .operators)
+        log("Mapping from \(T.self) to \(NewT.self). -- \(self)", logType: .operators)
         return newSub
     }
     
     /// Generates a new ValueOnlySubscriber of a different type, based on the supplied
     /// closure for mapping from one type to the other.
     @discardableResult func compactMap<NewT>(mapping: @escaping (T) -> NewT?) -> ValueOnlySubscriber<NewT> {
-        safePrint("Compact mapping from \(T.self) to \(NewT.self). -- \(self)", logType: .operators)
+        log("Compact mapping from \(T.self) to \(NewT.self). -- \(self)", logType: .operators)
         
         let newSub = ValueOnlySubscriber<NewT>()
         onNext { value in
@@ -240,7 +240,7 @@ public extension ValueOnlySubscriber where T: Equatable {
             new.cancel()
         }
         
-        safePrint(
+        log(
             "Removing contiguous duplicates from \(self)",
             logType: .operators
         )
@@ -422,13 +422,13 @@ private func logMessageForCombining<T1, T2>(_ sub1: ValueOnlySubscriber<T1>, and
 private func logForCombiningIfPossible<T1,T2>(_ sub1: ValueOnlySubscriber<T1>, _ sub2: ValueOnlySubscriber<T2>) {
     // This logging logic will probably become a problem at some point.
     if sub1.loggingCombo != nil {
-        sub1.safePrint(
+        sub1.log(
             logMessageForCombining(sub1, and: sub2),
             logType: .operators
         )
     }
     else if sub2.loggingCombo != nil {
-        sub2.safePrint(
+        sub2.log(
             logMessageForCombining(sub1, and: sub2),
             logType: .operators
         )


### PR DESCRIPTION
- Updated logging/printing for Publisher, Subscriber, and ValueOnlySubscriber so each logging site doesn't have to pass `loggingCombo`.
- Updated all the logging instance methods to be named `log(_:logType:)`